### PR TITLE
your-freedom: Added less strict conflict option, added comments

### DIFF
--- a/srcpkgs/your-freedom/template
+++ b/srcpkgs/your-freedom/template
@@ -1,0 +1,37 @@
+# Template file for 'your-freedom'
+pkgname=your-freedom
+version=20200720
+_gitver=422117840a1af6c0db5e77818739808e1444eae3
+revision=1
+create_wrksrc=yes
+build_style=meta
+short_desc="Conflicts with nonfree packages to ensure your system is free"
+maintainer="reback00 <reback00@protonmail.com>"
+license="GPL-3.0-or-later"
+homepage="https://git.parabola.nu/blacklist.git"
+distfiles="https://git.parabola.nu/blacklist.git/plain/blacklist.txt?id=${_gitver}>blacklist.txt"
+checksum=d6886831a73cf4af0ee5e564106a4b21ddd2d702d6bb1d5146355f1c86751789
+
+# Note 1: This package is still under testing. It is inspired by the Parabola's
+# your-freedom package. However, libretools is not explored yet.
+
+# Note 2: If you are building this package locally and have built it in the
+# past it is a good idea to clean cache to remove any history of it's conflict
+# data from past versions:
+#   $ rm hostdir/binpkgs/{*-repodata,your-freedom-*.xbps}
+
+# Commands outside functions run multiple times.
+# Setting $conflicts once does not work (it forgets it next time).
+# There is no way to determine which run will set the conflict correctly.
+# This is a workaround to set it when the $conflicts is found as being empty.
+if [ -z "$conflicts" ] && [ -f "$XBPS_SRCDISTDIR/${pkgname}-${version}/blacklist.txt" ]; then
+
+	cd "$XBPS_SRCDISTDIR/${pkgname}-${version}"
+	conflicts=$(awk -F ':' '{print $1}' "blacklist.txt" | awk '{print}' ORS=' ')
+	# Use the line below instead to whitelist some packages that have minor
+	# issues (like branding, suggesting optional dependencies etc.). But it
+	# should be used with caution because if you're not careful some nonfree
+	# packages may come through.
+	#conflicts=$(awk -F ':' '{ if ( $1 != $2) {print $1} }' "blacklist.txt" | awk '{print}' ORS=' ')
+
+fi


### PR DESCRIPTION
- Added a less strict conflict option on template (commented by default).

When uncommented, this option allows packages with minor issues (like branding, suggesting non-free packages as optional deps etc.) are allowed. This is done by whitelisting items that have common value on blacklist.txt on column 1 and 2. Caution has to be taken when this is used, because it is not well tested. So some nonfree packages might get through. This can be used as a temporary optional fix before packages are actually "liberated". For example, you can't even have both your-freedom and grub2 now just because of some minor branding issues. This option can help you allow them. GNU purists should stay away from this option. ;)

- Added comments about conflict cache and many other things.