### PR TITLE
your-freedom: Cleared libxfce4ui

### DIFF
--- a/srcpkgs/your-freedom/allowlist.txt
+++ b/srcpkgs/your-freedom/allowlist.txt
@@ -1,1 +1,1 @@
-
+libxfce4ui


### PR DESCRIPTION
Cleared libxfce4ui because it does not have mentions of "Arch Linux" on Void template, like [Arch does](https://github.com/archlinux/svntogit-packages/blob/packages/libxfce4ui/trunk/PKGBUILD) with `--with-vendor-info='Arch Linux'`.

It seems it's safe to avoid `--with-vendor-info` param (it does not get distro name instead, only gets xfce version):
https://github.com/xfce-mirror/libxfce4ui/blob/2301e67188a09a20c9bd3b209e46f226ad4cec5a/xfce4-about/main.c#L551

So Void template is libre already.