### PR TITLE
Liberated unzip

### DIFF
--- a/srcpkgs/unzip/patches/liberation.patch
+++ b/srcpkgs/unzip/patches/liberation.patch
@@ -1,0 +1,22 @@
+diff -Naurp1 unzip60.orig/match.c unzip60/match.c
+--- unzip60.orig/match.c	2005-08-14 23:00:36.000000000 +0600
++++ unzip60/match.c	2020-08-04 20:07:08.645312583 +0600
+@@ -29,12 +29,9 @@
+ 
+-  Copyright on recmatch() from Zip's util.c (although recmatch() was almost
+-  certainly written by Mark Adler...ask me how I can tell :-) ):
++  Copyright on recmatch() from Zip's util.c
++     Copyright (c) 1990-2005 Info-ZIP.  All rights reserved.
+ 
+-     Copyright (C) 1990-1992 Mark Adler, Richard B. Wales, Jean-loup Gailly,
+-     Kai Uwe Rommel and Igor Mandrichenko.
+-
+-     Permission is granted to any individual or institution to use, copy,
+-     or redistribute this software so long as all of the original files are
+-     included unmodified, that it is not sold for profit, and that this copy-
+-     right notice is retained.
++     See the accompanying file LICENSE, version 2004-May-22 or later
++     for terms of use.
++     If, for some reason, both of these files are missing, the Info-ZIP license
++     also may be found at:  ftp://ftp.info-zip.org/pub/infozip/license.html  
+ 

--- a/srcpkgs/your-freedom/allowlist.txt
+++ b/srcpkgs/your-freedom/allowlist.txt
@@ -1,3 +1,4 @@
 libxfce4ui
 minitube
 grub
+unzip


### PR DESCRIPTION
Solves the complain:

> [semifree] contains a source file that doesn't mention modification

- Applied only license related changes from Parabola's [match.patch](https://git.parabola.nu/abslibre.git/tree/libre/unzip/match.patch) for the above complain