### PR TITLE
your-freedom: Added feature to distinguish libre packages

### DIFF
--- a/srcpkgs/your-freedom/allowlist.txt
+++ b/srcpkgs/your-freedom/allowlist.txt
@@ -1,4 +1,4 @@
-libxfce4ui
+libxfce4ui:libxfce4ui
 minitube
 grub
 unzip

--- a/srcpkgs/your-freedom/denylist.txt
+++ b/srcpkgs/your-freedom/denylist.txt
@@ -1,0 +1,1 @@
+p7zip-unrar

--- a/srcpkgs/your-freedom/template
+++ b/srcpkgs/your-freedom/template
@@ -10,7 +10,7 @@ maintainer="reback00 <reback00@protonmail.com>"
 license="GPL-3.0-or-later"
 homepage="https://git.parabola.nu/blacklist.git"
 distfiles="https://git.parabola.nu/blacklist.git/plain/blacklist.txt?id=${_gitver}>blacklist.txt"
-checksum=d6886831a73cf4af0ee5e564106a4b21ddd2d702d6bb1d5146355f1c86751789
+checksum=c7045a60f242fc669e8f097e4d49ba6d34bd06973a9090b63083e5a5d6bfc2f6
 
 # Set this below to yes to allow some packages that have minor issues
 # (like branding, suggesting optional dependencies etc.). But it should
@@ -23,6 +23,12 @@ allow_semifree=no
 # each line. If you change the file, remember to clear cache according
 # to the note below in the comment.
 use_allowlist=yes
+
+# Set this below to yes to enable denying packages listed on denylist.txt.
+# Packages listed on that file will be added to the conflicts list. Useful for
+# packages not listed on Parabola's blacklist.txt but present on Void. List
+# each package name on each line of that file.
+use_denylist=yes
 
 
 # Note 1: This package is still under testing. It is inspired by the Parabola's
@@ -46,6 +52,14 @@ if [ -z "$conflicts" ] && [ -f "$XBPS_SRCDISTDIR/${pkgname}-${version}/blacklist
 		conflicts=$(awk -F ':' '{ if ( $1 != $2) {print $1} }' "blacklist.txt" | awk '{print}' ORS=' ')
 	else
 		conflicts=$(awk -F ':' '{print $1}' "blacklist.txt" | awk '{print}' ORS=' ')
+	fi
+
+	if [ "$use_denylist" == "yes" ] && [ -f "${XBPS_SRCPKGDIR}/${pkgname}/denylist.txt" ]; then
+		while read package; do
+			if [ "$package" != "" ]; then
+				conflicts="$conflicts $package"
+			fi
+		done < "${XBPS_SRCPKGDIR}/${pkgname}/denylist.txt"
 	fi
 
 	if [ "$use_allowlist" == "yes" ] && [ -f "${XBPS_SRCPKGDIR}/${pkgname}/allowlist.txt" ]; then

--- a/srcpkgs/your-freedom/template
+++ b/srcpkgs/your-freedom/template
@@ -19,9 +19,11 @@ checksum=c7045a60f242fc669e8f097e4d49ba6d34bd06973a9090b63083e5a5d6bfc2f6
 allow_semifree=no
 
 # Set this below to yes to allow some packages listed on allowlist.txt.
-# allowlist.txt should list each package name that should be allowed on
-# each line. If you change the file, remember to clear cache according
-# to the note below in the comment.
+# allowlist.txt should list each package name that should be allowed on each
+# line. In case some package is already libre on default repo and should be
+# indicated, enter the package name twice adding a ":" between them. If you
+# change the file, remember to clear cache according to the note below in the
+# comment.
 use_allowlist=yes
 
 # Set this below to yes to enable denying packages listed on denylist.txt.
@@ -63,8 +65,9 @@ if [ -z "$conflicts" ] && [ -f "$XBPS_SRCDISTDIR/${pkgname}-${version}/blacklist
 	fi
 
 	if [ "$use_allowlist" == "yes" ] && [ -f "${XBPS_SRCPKGDIR}/${pkgname}/allowlist.txt" ]; then
-		while read package; do
-			if [ "$package" != "" ]; then
+		while read linedata; do
+			if [ "$linedata" != "" ]; then
+				package=$( echo "$linedata" | awk -F ':' '{print $1}' )
 				if [ "$expr" == "" ]; then
 					expr="$package\s*"
 				else


### PR DESCRIPTION
Added a feature to add the package entry on allowlist.txt in such
a way that it is distinguishable if the package is already libre on
default repo and build should be skipped for it on a custom repo.

Should fix #19 