### PR TITLE
Allowed acpi_call-dkms, sorted allowlist

### DIFF
--- a/srcpkgs/your-freedom/allowlist.txt
+++ b/srcpkgs/your-freedom/allowlist.txt
@@ -1,4 +1,5 @@
+acpi_call-dkms:acpi_call-dkms
+grub
 libxfce4ui:libxfce4ui
 minitube
-grub
 unzip


### PR DESCRIPTION
- Allowed `acpi_call-dkms` according to [this comment](https://github.com/drake-newell/void-packages/issues/16#issuecomment-670959854).
- Sorted `allowlist.txt` package names alphabetically to aid in maintenance.