### PR TITLE
your-freedom: Allowed engrampa

### DIFF
--- a/srcpkgs/your-freedom/allowlist.txt
+++ b/srcpkgs/your-freedom/allowlist.txt
@@ -1,4 +1,5 @@
 acpi_call-dkms:acpi_call-dkms
+engrampa:engrampa
 grub
 libxfce4ui:libxfce4ui
 minitube


### PR DESCRIPTION
Because Void's engrampa doesn't have unrar and unace deps.

Complain was:

> [uses-nonfree] recommends nonfree unrar and unace installation